### PR TITLE
Fix cli-only output_dir exception

### DIFF
--- a/gogitit/manifest.py
+++ b/gogitit/manifest.py
@@ -59,7 +59,7 @@ class Manifest(object):
     def __init__(self, path, cache_dir, **kwargs):
         self.path = path
         self.cache_dir = cache_dir
-        self.output_dir = kwargs['output_dir']
+        self.output_dir = kwargs.get('output_dir', None)
         self.repos = []
         for r in kwargs['repos']:
             self.repos.append(Repo(self, cache_dir, **r))


### PR DESCRIPTION
When no output_dir is specified in manifest but one is specifed on the CLI.

```
14:15:52 + gogitit sync -m res/gogitit/online_int.yml -o vendored/gogitit
...
14:15:52 Traceback (most recent call last):
14:15:52   File "/usr/bin/gogitit", line 9, in <module>
14:15:52     load_entry_point('gogitit==0.5', 'console_scripts', 'gogitit')()
14:15:52   File "/usr/lib/python2.7/site-packages/click/core.py", line 716, in __call__
14:15:52     return self.main(*args, **kwargs)
14:15:52   File "/usr/lib/python2.7/site-packages/click/core.py", line 696, in main
14:15:52     rv = self.invoke(ctx)
14:15:52   File "/usr/lib/python2.7/site-packages/click/core.py", line 1060, in invoke
14:15:52     return _process_result(sub_ctx.command.invoke(sub_ctx))
14:15:52   File "/usr/lib/python2.7/site-packages/click/core.py", line 889, in invoke
14:15:52     return ctx.invoke(self.callback, **ctx.params)
14:15:52   File "/usr/lib/python2.7/site-packages/click/core.py", line 534, in invoke
14:15:52     return callback(*args, **kwargs)
14:15:52   File "/usr/lib/python2.7/site-packages/gogitit/cli.py", line 33, in sync
14:15:52     manifest = gogitit.manifest.load(manifest_file, cache_dir)
14:15:52   File "/usr/lib/python2.7/site-packages/gogitit/manifest.py", line 24, in load
14:15:52     m = Manifest(f.name, cache_dir, **data)
14:15:52   File "/usr/lib/python2.7/site-packages/gogitit/manifest.py", line 32, in __init__
14:15:52     self.output_dir = kwargs['output_dir']
14:15:52 KeyError: 'output_dir'
```
